### PR TITLE
DE145600 : Web Integration API : Fix issue with document.currentScript in Firefox.

### DIFF
--- a/source/includes/_debugging.md
+++ b/source/includes/_debugging.md
@@ -4,7 +4,7 @@
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     if (ev.payload.searchPage) {
       API.log('My integration has loaded and this is a search results page.');

--- a/source/includes/_events.md
+++ b/source/includes/_events.md
@@ -211,7 +211,7 @@ To receive data for events, you must opt-in to event subscriptions. Each event i
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     API.log(ev);
   });
@@ -234,7 +234,7 @@ The page load event is useful to determine the context of the current page. By m
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('dealership-info-v1', ev => {
     API.log(ev);
   });
@@ -257,7 +257,7 @@ The dealership info event is useful if you need to know the name and address of 
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('vehicle-shown-v1', ev => {
     API.log(ev);
   });
@@ -281,7 +281,7 @@ On a vehicle deals page, a single event is fired because you are viewing a singl
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('vehicle-data-updated-v1', data => {
     API.log(data.payload.pageData); // Outputs the Page Data object to the console.
     API.log(data.payload.vehicleData); // Outputs the updated Vehicle Data object to the console.

--- a/source/includes/_locations.md
+++ b/source/includes/_locations.md
@@ -10,7 +10,7 @@ See the <a href="#api-insert-name-callback-elem-meta">insert documentation</a> f
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('vehicle-media', (elem, meta) => {
     // This element is positioned below the vehicle image area on vehicle search pages.
   });
@@ -21,7 +21,7 @@ See the <a href="#api-insert-name-callback-elem-meta">insert documentation</a> f
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     if (ev.payload.searchPage) {
       API.insert('vehicle-media', (elem, meta) => {
@@ -49,7 +49,7 @@ This element is positioned below the vehicle image area on vehicle search pages.
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('vehicle-badge', (elem, meta) => {
     // This element is positioned below the vehicle tech specs area on vehicle search and detail pages.
   });
@@ -60,7 +60,7 @@ This element is positioned below the vehicle image area on vehicle search pages.
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     if (ev.payload.searchPage || ev.payload.detailPage) {
       API.insert('vehicle-badge', (elem, meta) => {
@@ -94,7 +94,7 @@ This element is positioned below the vehicle tech specs area on vehicle search a
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('vehicle-pricing', (elem, meta) => {
     // This element is positioned below the vehicle pricing area on vehicle search and detail pages.
   });
@@ -105,7 +105,7 @@ This element is positioned below the vehicle tech specs area on vehicle search a
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     // Only execute the code on search results and vehicle details pages.
     if (ev.payload.searchPage || ev.payload.detailPage) {
@@ -133,7 +133,7 @@ This element is positioned below the vehicle pricing area on vehicle search and 
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('vehicle-media-container', (elem, meta) => {
     // This element is the media gallery container on vehicle details pages.
     // Injecting into this location will replace the media gallery with the elements you insert.
@@ -145,7 +145,7 @@ This element is positioned below the vehicle pricing area on vehicle search and 
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     if (ev.payload.detailPage) {
       API.insert('vehicle-media-container', (elem, meta) => {
@@ -167,7 +167,7 @@ This element is the media gallery container on vehicle details pages. Injecting 
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('primary-banner', (elem, meta) => {
     // This element is typically positioned in a prominent location above the vehicle listings on the Search Results Page.
     // On the Details page, it is near the top of the vehicle information, below the media gallery.
@@ -179,7 +179,7 @@ This element is the media gallery container on vehicle details pages. Injecting 
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     if (ev.payload.searchPage || ev.payload.detailPage) {
       API.insert('primary-banner', (elem, meta) => {
@@ -212,7 +212,7 @@ You can target either the listings or details page by first subscribing to the <
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('secondary-content', (elem, meta) => {
     // This element is the a secondary content container on vehicle details pages roughly 2/3 of the way down.
     // It may also be added custom to one or more standalone pages on the website.
@@ -224,7 +224,7 @@ You can target either the listings or details page by first subscribing to the <
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     if (ev.payload.detailPage) {
       API.insert('secondary-content', (elem, meta) => {
@@ -248,7 +248,7 @@ Since this may also be present on one or two standalone pages as custom addition
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('content', (elem, meta) => {
     // This element is will only insert on pages created by us for your purposes.
     // It may also be present on pages created for another integration.
@@ -260,7 +260,7 @@ Since this may also be present on one or two standalone pages as custom addition
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('page-load-v1', ev => {
     if (ev.payload.pageName === 'YOUR_LANDING_PAGE') { // Note: Replace 'pageName' with the one we provide at page creation.
       API.insert('content', (elem, meta) => {

--- a/source/includes/_methods.md
+++ b/source/includes/_methods.md
@@ -6,7 +6,7 @@
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('event-name-and-version', ev => {
     API.log(ev);
   });
@@ -20,7 +20,7 @@ Please see the <a href="#event-subscriptions">specific event documentation</a> f
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insertCallToAction('button', 'value-a-trade', meta => {
     return {
       "type": "default",
@@ -113,7 +113,7 @@ After creating the callback object, you must then return it for the API to creat
 (async APILoader => {
 
   // Initialize an instance of the API
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
 
   // Receive a notification each time vehicle data is updated on the page (or a new page is loaded).
   API.subscribe('vehicle-data-updated-v1', ev => {
@@ -165,7 +165,7 @@ Field Name | Purpose | Field Format
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insertGalleryContent('vehicle-media', [
     {
       type: 'image',
@@ -207,7 +207,7 @@ Name | Description
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('location-name', (elem, meta) => {
     API.log(elem); // The DOM element where markup may be inserted.
     API.log(meta); // The payload object for the current insertion point.
@@ -229,7 +229,7 @@ If you need to execute additional code before determining if you wish to insert 
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   // Receive a notification each time vehicle data is updated on the page (or a new page is loaded).
   API.subscribe('vehicle-data-updated-v1', ev => {
     // Insert content into each vehicle location now present on the page.
@@ -247,7 +247,7 @@ If you need to execute additional code before determining if you wish to insert 
 (async APILoader => {
 
   // Initialize an instance of the API
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
 
   // Receive a notification each time vehicle data is updated on the page (or a new page is loaded).
   API.subscribe('vehicle-data-updated-v1', ev => {
@@ -298,7 +298,7 @@ Field Name | Purpose | Field Format
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   const button = API.create('button', {
     href: 'https://www.google.com/',
     text: {
@@ -364,7 +364,7 @@ Field Key | Example Value | Field Format | Purpose
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.append(targetEl, appendEl);
 })(window.DDC.APILoader);
 ```
@@ -373,7 +373,7 @@ Field Key | Example Value | Field Format | Purpose
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.insert('target-location-name', (elem, meta) => {
     let lowPrice = Math.round(meta.finalPrice - 1000);
     let highPrice = Math.round(meta.finalPrice + 1000);
@@ -399,7 +399,7 @@ When calling the insert method, the goal is to insert some markup into a locatio
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   // Loads a JavaScript file
   API.loadJS('https://www.company.com/script.js')
     .then(() => {
@@ -416,7 +416,7 @@ The loadJS method is a simple way to include additional JavaScript files require
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   // Loads a CSS stylesheet
   API.loadCSS('https://www.company.com/integration.css')
     .then(() => {

--- a/source/includes/_requirements.md
+++ b/source/includes/_requirements.md
@@ -18,7 +18,7 @@ When you begin development of your script, it's easy to test on any Dealer.com s
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.test('https://www.yourdomain.com/your-javascript-file.js');
 })(window.DDC.APILoader);
 ```
@@ -41,7 +41,7 @@ Your code should be minimal and perform only actions necessary to bootstrap your
 
 ```javascript
 (async APILoader => {
-	const API = await APILoader.create();
+	const API = await APILoader.create(document.currentScript);
 	// API.subscribe(...);
 	// Your code here
 })(window.DDC.APILoader);

--- a/source/includes/_samples.md
+++ b/source/includes/_samples.md
@@ -29,7 +29,7 @@ if (window.ResizeObserver) {
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
 
   API.insert('content', (elem, meta) => {
     const iframeElem = document.createElement('iframe');

--- a/source/includes/_utilities.md
+++ b/source/includes/_utilities.md
@@ -8,7 +8,7 @@ In addition to the event based system for working with sites, some utility metho
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.subscribe('vehicle-data-updated-v1', data => {
 
     API.log(data.payload.pageData); // Logs the Page Data object
@@ -36,7 +36,7 @@ This can be used to obtain an array of attributes for the currently displayed ve
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   const testConfig = {
     dealerId: "12345",
     showOnSRP: true,
@@ -60,7 +60,7 @@ This fetches a JavaScript object of your integration's configuration for the cur
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.utils.getDealerData().then(dealerData => {
     // Logs the Dealership Info Event object for the current website.
     API.log(dealerData);
@@ -76,7 +76,7 @@ This fetches the <a href="#dealership-info-event">Dealership Info Event object</
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.utils.getJwtForSite().then(jwtObject => {
     API.log(jwtObject);
     // Returns a data structure like this:
@@ -96,7 +96,7 @@ This fetches an object containing a Java Web Token which can be used to secure/v
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.utils.getJwtForVehicles().then(jwtObject => {
     API.log(jwtObject);
     // Returns a data structure like this:
@@ -116,7 +116,7 @@ This fetches an object containing the array of VINs on the current page and a co
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   API.utils.getPageData().then(pageData => {
     // Outputs the Page Data Object for the current page.
     API.log(pageData);
@@ -132,7 +132,7 @@ This fetches the <a href="#page-event">Page Event object</a> for the current web
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   const urlParams = API.utils.getUrlParams(); // Returns the current URL parameters as object attributes, so you can easily access the values.
   API.log(urlParams); // Log the entire object.
   API.log(urlParams.query); // Access just the `query` parameter, for example.
@@ -161,7 +161,7 @@ Will return the following object:
 
 ```javascript
 (async APILoader => {
-  const API = await APILoader.create();
+  const API = await APILoader.create(document.currentScript);
   const config = API.utils.getVehicleData().then(vehicleData => {
     // Outputs the current set of vehicle data.
     API.log(vehicleData);


### PR DESCRIPTION
To make this work, we have to pass `document.currentScript` into the `APILoader.create` function so that the context of which script is being executed can be retained when that script later calls the API.