### PR TITLE
Clarifying IPP requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Updated
+
+-   Updated the requirement documentation.
 
 ## [v2021-09-13T19.26.36] - 2021-09-13
 

--- a/source/includes/_requirements.md
+++ b/source/includes/_requirements.md
@@ -2,7 +2,7 @@
 
 ## Integrated Partner Program
 
-The use of this API requires that you are enrolled in our Integrated Partner Program. To find out more information or to enroll, please contact us at <a href="mailto:IntegratedPartners@coxautoinc.com"> IntegratedPartners@coxautoinc.com</a> or <a href="https://forms.dealer.com/integrated-partner-program.htm" target="_blank">fill out this form</a>.
+The use of this API requires that you are in communication with our Integrated Partner Program. To find out more information or to enroll, please contact us at <a href="mailto:IntegratedPartners@coxautoinc.com"> IntegratedPartners@coxautoinc.com</a> or <a href="https://forms.dealer.com/integrated-partner-program.htm" target="_blank">fill out this form</a>.
 
 Once enrolled, you will be provided with an integration key to use when making API calls.
 


### PR DESCRIPTION
Making the requirements for interaction with the Integrated Partner Program technically more accurate. Third Parties can sign up with with IPP or just sign a service level agreement. IPP/Chris Vargo can sort that out with them so they just need to be in communication with us.